### PR TITLE
Fixes and addition of new final rubric field

### DIFF
--- a/app/dashboard/tasks/[taskId]/page.tsx
+++ b/app/dashboard/tasks/[taskId]/page.tsx
@@ -444,7 +444,7 @@ export default function TaskDetailsPage() {
           <div className="space-y-1">
             <div className="flex items-center space-x-3">
               <h1 className="text-3xl font-bold tracking-tight text-foreground">
-                {task.TaskID}
+                {task.TaskID.split("-")[0]}...
               </h1>
               <Badge className={statusInfo.color} variant="outline">
                 {statusInfo.label}

--- a/lib/schemas/task.ts
+++ b/lib/schemas/task.ts
@@ -133,6 +133,7 @@ export interface AirtableTaskRecord extends FieldSet {
   Misaligned_GPT?: string; // JSON array - Misaligned items for GPT
 
   Alignment_History?: string;
+  Final_Rubric?: string;
 
   // Optional comments
   Comments?: string; // General comments about the evaluation

--- a/lib/trpc/routers/tasks.ts
+++ b/lib/trpc/routers/tasks.ts
@@ -332,7 +332,8 @@ export const tasksRouter = router({
           {
             id: existingRecord.id,
             fields: {
-              Rubric_V1: input.rubricV1, // Now contains new format JSON
+              Rubric_V1: input.rubricV1,
+              Final_Rubric: input.rubricV1,
               Status: "Rubric_V1" as TaskStatus,
             },
           },
@@ -472,8 +473,9 @@ export const tasksRouter = router({
         // Update the record with the new version
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const updateFields: any = {
-          [rubricFieldName]: input.rubricContent, // New format JSON
+          [rubricFieldName]: input.rubricContent,
           Current_Rubric_Version: input.targetVersion,
+          Final_Rubric: input.rubricContent,
           Status: nextStatus,
         };
 

--- a/lib/trpc/routers/users.ts
+++ b/lib/trpc/routers/users.ts
@@ -101,7 +101,7 @@ export const usersRouter = router({
       if (currentUserInfo.role !== "admin") {
         throw new TRPCError({
           code: "FORBIDDEN",
-          message: "Admin privilegs required",
+          message: "Admin privileges required",
         });
       }
 

--- a/lib/trpc/routers/users.ts
+++ b/lib/trpc/routers/users.ts
@@ -279,7 +279,7 @@ export const usersRouter = router({
         if (currentUserInfo.role !== "admin") {
           throw new TRPCError({
             code: "FORBIDDEN",
-            message: "Admin privilegs required",
+            message: "Admin privileges required",
           });
         }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,7 +30,7 @@ export async function middleware(request: NextRequest) {
       const userRole = userInfo?.role;
 
       if (!userRole || userRole !== "admin") {
-        console.warn("Unuathorized admin access attempt", {
+        console.warn("Unauthorized admin access attempt", {
           url: request.nextUrl.pathname,
           userId: session.user.sub,
           role: userRole,


### PR DESCRIPTION
This pull request introduces changes to improve task display, enhance schema handling for task rubrics, and fix minor typos in error messages and logs. Below is a detailed summary of the most important changes:

### Task Display Improvements:
* Updated the `TaskDetailsPage` component to display a shortened version of the `TaskID` by splitting it at the first hyphen and appending ellipses (`...`). (`app/dashboard/tasks/[taskId]/page.tsx`, [app/dashboard/tasks/[taskId]/page.tsxL447-R447](diffhunk://#diff-684e379f1e7f42cefaa3b2ff6b7bbd493bbd45c9433af41b4d685f02cde1f8ccL447-R447))

### Schema Enhancements:
* Added a new `Final_Rubric` field to the `AirtableTaskRecord` interface to support storing the final rubric version. (`lib/schemas/task.ts`, [lib/schemas/task.tsR136](diffhunk://#diff-41733fc799addff653f5208be0b9a443f9d1c708f987960a07780e4f68fcb934R136))

### Task Router Updates:
* Modified the `tasksRouter` to populate the `Final_Rubric` field with the same value as `Rubric_V1` when updating task records. (`lib/trpc/routers/tasks.ts`, [[1]](diffhunk://#diff-1dda6e7aab5c544f307f8a88d2d8528dd7283437e978159b636ae4f77c8d9fccL335-R336) [[2]](diffhunk://#diff-1dda6e7aab5c544f307f8a88d2d8528dd7283437e978159b636ae4f77c8d9fccL475-R478)

### Typo Fixes:
* Corrected "Admin privilegs required" to "Admin privileges required" in error messages thrown in the `usersRouter`. (`lib/trpc/routers/users.ts`, [[1]](diffhunk://#diff-475157a3e0426535f43a3b4409cbedab190d9a301e3636b416539be02186c49fL104-R104) [[2]](diffhunk://#diff-475157a3e0426535f43a3b4409cbedab190d9a301e3636b416539be02186c49fL282-R282)
* Fixed a typo in a log message from "Unuathorized" to "Unauthorized" in the `middleware` function. (`middleware.ts`, [middleware.tsL33-R33](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL33-R33))